### PR TITLE
feat: add optional You.com web search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,19 @@ We’re actively adding a one-click "Resync" button in the UI, followed by autom
 
 The MCP server is available at `http://localhost:3000/api/mcp` and is designed for coding agents and MCP-compatible clients. It exposes a `codebase-qna` tool that answers repository-scoped questions by querying the analysis databases that AutoDocs produces.
 
+If you set `YDC_API_KEY`, the MCP agent also gets an optional `search_web` tool for pulling in external context from You.com when repo-local search is not enough.
+
 Tips
 
 - Point your MCP client at `http://localhost:3000/api/mcp`.
 - Include an `x-repo-id` header with the repo ID (you can find it in the UI).
 - For setup guides with popular tools (Claude, Cursor, Continue), see https://docs.trysita.com
+
+Optional web search:
+
+```bash
+export YDC_API_KEY="your-key-here"
+```
 
 ## Development Workflow (for contributing)
 

--- a/webview/packages/shared/src/tools/batchSearchTool.ts
+++ b/webview/packages/shared/src/tools/batchSearchTool.ts
@@ -3,6 +3,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 import { SupabaseDb } from '../db';
 import { SearchItemSchema, type SemanticSearchResult } from '../types';
 import { semanticSearch } from './semantic-search';
+import { searchWeb as searchYoucomWeb } from './youcom-search';
 
 // Tool parameters schema
 export const BatchSearchParameters = z
@@ -23,6 +24,21 @@ export const BATCH_SEARCH_TOOL_SCHEMA = {
   name: 'batch_search_codebase',
   description: 'Run parallel semantic searches across the codebase',
   parameters: zodToJsonSchema(BatchSearchParameters),
+  strict: false,
+};
+
+export const WEB_SEARCH_TOOL_SCHEMA = {
+  type: 'function' as const,
+  name: 'search_web',
+  description: 'Search the web for external context when codebase search is not enough',
+  parameters: zodToJsonSchema(
+    z
+      .object({
+        query: z.string().min(1).max(400),
+        count: z.number().int().min(1).max(10).optional(),
+      })
+      .strict(),
+  ),
   strict: false,
 };
 
@@ -104,4 +120,8 @@ export async function batchSearchCodebases(
   });
 
   return { results };
+}
+
+export async function webSearch(query: string, count = 5): Promise<{ query: string; result: string }> {
+  return searchYoucomWeb(query, count);
 }

--- a/webview/packages/shared/src/tools/sendMCPMessage.ts
+++ b/webview/packages/shared/src/tools/sendMCPMessage.ts
@@ -5,6 +5,8 @@ import {
   BATCH_SEARCH_TOOL_SCHEMA,
   batchSearchCodebases,
   BatchSearchParams,
+  WEB_SEARCH_TOOL_SCHEMA,
+  webSearch,
 } from './batchSearchTool';
 
 // Configuration constants for easy tuning
@@ -53,6 +55,11 @@ You serve as an MCP Q&A server for codebases. Your core objective is to answer t
 - Use for questions like “How does X work?”, “Where is Y implemented?”, or “What handles Z?”
 - Run 3–5 focused queries (e.g., synonyms, framework terms, symbol names, error strings).
 - Adjust \`k\` (5–10) for optimal coverage versus precision.
+
+**Optional tool:** \`search_web\`
+
+- Use when the answer may depend on external docs, APIs, release notes, or ecosystem context that is not in the repo.
+- Keep the query focused and prefer it only when codebase search alone is not enough.
 
 # Retrieval Strategy
 
@@ -164,7 +171,9 @@ function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
   });
 }
 
-const TOOLS = [BATCH_SEARCH_TOOL_SCHEMA];
+const TOOLS = process.env.YDC_API_KEY
+  ? [BATCH_SEARCH_TOOL_SCHEMA, WEB_SEARCH_TOOL_SCHEMA]
+  : [BATCH_SEARCH_TOOL_SCHEMA];
 
 // Lazily construct the OpenAI client. Validating OPENAI_API_KEY at module load
 // would crash any consumer of @sita/shared (the package re-exports this module
@@ -307,12 +316,21 @@ export async function runWithBudgets(opts: LoopOpts): Promise<string> {
         const started = Date.now();
 
         try {
-          let toolResult: { results: Array<{ query: string; result: string }> } | { error: string };
+          let toolResult:
+            | { results: Array<{ query: string; result: string }> }
+            | { query: string; result: string }
+            | { error: string };
 
           if (call.name === 'batch_search_codebase') {
             const args: BatchSearchParams = JSON.parse(call.arguments);
             toolResult = await withTimeout(
               batchSearchCodebases(args, opts.repoSlug, opts.responseType),
+              opts.toolTimeoutMs,
+            );
+          } else if (call.name === 'search_web') {
+            const args = JSON.parse(call.arguments) as { query: string; count?: number };
+            toolResult = await withTimeout(
+              webSearch(args.query, args.count ?? 5),
               opts.toolTimeoutMs,
             );
           } else {
@@ -324,7 +342,12 @@ export async function runWithBudgets(opts: LoopOpts): Promise<string> {
             name: call.name,
             call_id: call.call_id,
             ms: Date.now() - started,
-            summary: 'results' in toolResult ? { batches: toolResult.results.length } : undefined,
+            summary:
+              'results' in toolResult
+                ? { batches: toolResult.results.length }
+                : 'result' in toolResult
+                  ? { batches: 1 }
+                  : undefined,
           });
 
           // Append as a tool message so the model can use it next turn

--- a/webview/packages/shared/src/tools/youcom-search.ts
+++ b/webview/packages/shared/src/tools/youcom-search.ts
@@ -1,0 +1,85 @@
+type YoucomSearchResult = {
+  url: string;
+  title?: string;
+  description?: string;
+  snippets?: string[];
+};
+
+type YoucomSearchResponse = {
+  results?: {
+    web?: YoucomSearchResult[];
+    news?: YoucomSearchResult[];
+  };
+};
+
+function getYoucomApiKey(): string | null {
+  return process.env.YDC_API_KEY ?? null;
+}
+
+function formatResults(results: YoucomSearchResult[]): string {
+  if (results.length === 0) {
+    return 'No results found.';
+  }
+
+  return results
+    .slice(0, 5)
+    .map((result, index) => {
+      const snippets = result.snippets?.length ? `\n  Snippets: ${result.snippets.join(' | ')}` : '';
+      const description = result.description ? `\n  Summary: ${result.description}` : '';
+      return `${index + 1}. ${result.title ?? 'Untitled result'}\n  URL: ${result.url}${description}${snippets}`;
+    })
+    .join('\n\n');
+}
+
+export async function searchWeb(
+  query: string,
+  count = 5,
+): Promise<{ query: string; result: string }> {
+  const apiKey = getYoucomApiKey();
+  if (!apiKey) {
+    return {
+      query,
+      result: 'You.com search is not enabled. Set YDC_API_KEY to use the optional external web search tool.',
+    };
+  }
+
+  const url = new URL('https://ydc-index.io/v1/search');
+  url.searchParams.set('query', query);
+  url.searchParams.set('count', String(count));
+  url.searchParams.set('safesearch', 'moderate');
+
+  try {
+    const resp = await fetch(url, {
+      headers: {
+        'X-API-Key': apiKey,
+      },
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text();
+      return {
+        query,
+        result: `You.com search failed with HTTP ${resp.status}: ${body}`,
+      };
+    }
+
+    const data = (await resp.json()) as YoucomSearchResponse;
+    const webResults = data.results?.web ?? [];
+    const newsResults = data.results?.news ?? [];
+
+    return {
+      query,
+      result: [
+        `Query: ${query}`,
+        webResults.length > 0 ? `Web results:\n${formatResults(webResults)}` : 'Web results: none',
+        newsResults.length > 0 ? `News results:\n${formatResults(newsResults)}` : 'News results: none',
+      ].join('\n\n'),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      query,
+      result: `You.com search failed: ${message}`,
+    };
+  }
+}


### PR DESCRIPTION
This keeps the default codebase search path intact and adds an optional You.com-backed `search_web` tool for cases where external docs, release notes, or ecosystem context help answer a question.

What changed:
- Added a small You.com Search API helper in `@sita/shared`
- Exposed a new `search_web` MCP tool when `YDC_API_KEY` is set
- Wired the MCP prompt to use it only when repo-local search is not enough
- Documented the env var in the README

Setup:
```bash
export YDC_API_KEY="your-key-here"
```

Usage:
- Use the normal MCP flow, and the agent can call `search_web` for external context.

Fallback behavior:
- If `YDC_API_KEY` is missing, the tool is not exposed.
- HTTP failures return a readable error payload instead of breaking the chat loop.

Validation:
- `pnpm install --ignore-scripts`
- `node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/bin/tsc -p packages/shared/tsconfig.json --noEmit`

Tracking issue:
- https://github.com/youdotcom-oss/integration-tracking/issues/61
